### PR TITLE
Option to pass virtual pin in message

### DIFF
--- a/blynk-ws.js
+++ b/blynk-ws.js
@@ -755,7 +755,8 @@ module.exports = function(RED) {
             if (msg.hasOwnProperty("payload") && node.serverConfig && node.serverConfig.logged) {
                 var payload = Buffer.isBuffer(msg.payload) ? msg.payload : RED.util.ensureString(msg.payload);
                 var subject = msg.topic ? msg.topic : payload;
-                node.serverConfig.virtualWrite(node.pin, payload);
+                var pin = msg.pin ? msg.pin : node.pin;
+                node.serverConfig.virtualWrite(pin, payload);
             }
         });
     }

--- a/blynk-ws.js
+++ b/blynk-ws.js
@@ -733,7 +733,7 @@ module.exports = function(RED) {
                 node.status({
                     fill: "green",
                     shape: "dot",
-                    text: "connected to pin V" + node.pin
+                    text: "connected"
                 });
             });
             this.serverConfig.on('erro', function() {


### PR DESCRIPTION
Checking the message for a virtual pin definition allows for a greater flexibility without changing the current behaviour.

I use it to map MQTT topics to virtual pins in a function node and redirect it to a single blynk write node.